### PR TITLE
change embedded image styling for open tracking

### DIFF
--- a/src/gophish/models/template_context.go
+++ b/src/gophish/models/template_context.go
@@ -66,7 +66,7 @@ func NewPhishingTemplateContext(ctx TemplateContext, r BaseRecipient, rid string
 		BaseURL:       baseURL.String(),
 		URL:           phishURL.String(),
 		TrackingURL:   trackingURL.String(),
-		Tracker:       "<img alt='' style='display: none' src='" + trackingURL.String() + "'/>",
+		Tracker:       "<img width='1px' height='1px' alt='' src='" + trackingURL.String() + "'/>",
 		From:          fn,
 		RId:           rid,
 	}, nil

--- a/src/gophish/models/template_context_test.go
+++ b/src/gophish/models/template_context_test.go
@@ -40,7 +40,7 @@ func (s *ModelsSuite) TestNewTemplateContext(c *check.C) {
 		From:          "From Address",
 		RId:           r.RId,
 	}
-	expected.Tracker = "<img alt='' style='display: none' src='" + expected.TrackingURL + "'/>"
+	expected.Tracker = "<img width='1px' height='1px' alt='' src='" + expected.TrackingURL + "'/>"
 	got, err := NewPhishingTemplateContext(ctx, r.BaseRecipient, r.RId)
 	c.Assert(err, check.Equals, nil)
 	c.Assert(got, check.DeepEquals, expected)


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
Show tracking image in a 1px by 1px space.
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

<!-- Why is this change required? -->
We think by setting display: none, it's causing some issues in email clients. We're setting it this way, because that's how Mailgun sets there open tracking links and theirs is working.

<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
Ran locally and verified CSS worked.

<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] _All_ future TODOs are captured in issues, which are referenced
     in code comments.
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
* [x] Tests have been added and/or modified to cover the changes in this PR.
* [x] All new and existing tests pass.
